### PR TITLE
fix: allow Safari address bars to overlay starfield

### DIFF
--- a/v1-StarGPT_SLPT/index.html
+++ b/v1-StarGPT_SLPT/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="#090A0F">
     <title>Sleeper Roster & Ownership Tool</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1099,7 +1100,7 @@
 <style>
 
 /* === Replaced Background: Parallax Pixel Starfield (inline, single-file) === */
-html { height: 100%; overflow-y: auto !important; overflow-x: hidden !important; }
+html { height: 100%; overflow-y: auto !important; overflow-x: hidden !important; background: transparent; }
 body { min-height: 100%; background: transparent !important; }
 
 #starfield { 


### PR DESCRIPTION
## Summary
- add viewport-fit=cover and theme color meta tags
- make the root html background transparent so the starfield shows behind iOS bars

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a854d0cf40832e810dedbd894bd0d3