### PR TITLE
Make Safari mobile bars transparent

### DIFF
--- a/v1-StarGPT_SLPT/index.html
+++ b/v1-StarGPT_SLPT/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="rgba(0,0,0,0)">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <title>Sleeper Roster & Ownership Tool</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -58,16 +60,18 @@
       html, body {
         height: 100%;
         margin: 0;
+        background-color: #0b0b12;
       }
 
       body {
         font-family: var(--font-sans);
-        background-color: #0b0b12;
         color: var(--color-text-primary);
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         overflow-x: hidden;
         position: relative;
+        padding-top: env(safe-area-inset-top);
+        padding-bottom: env(safe-area-inset-bottom);
       }
 
       .content-wrapper {


### PR DESCRIPTION
## Summary
- Let Safari's top and bottom bars reveal the page background by adding transparent theme color and viewport-fit adjustments
- Add safe area padding and background color to ensure content extends behind Safari UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a854d0cf40832e810dedbd894bd0d3