### PR TITLE
Fix Safari address bar transparency

### DIFF
--- a/v1-StarGPT_SLPT/index.html
+++ b/v1-StarGPT_SLPT/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0b12">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <title>Sleeper Roster & Ownership Tool</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -58,6 +60,10 @@
       html, body {
         height: 100%;
         margin: 0;
+      }
+
+      html {
+        background-color: #0b0b12;
       }
 
       body {


### PR DESCRIPTION
## Summary
- ensure Safari uses the page background for its UI bars by adding theme color and status bar meta tags
- allow content to extend under iOS safe areas via viewport-fit
- set the html background color so the address bars render transparent instead of white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a854d0cf40832e810dedbd894bd0d3